### PR TITLE
Modified Manga CSS Hover Styling

### DIFF
--- a/Website/style.css
+++ b/Website/style.css
@@ -208,17 +208,29 @@ publication{
     flex-shrink: 0;
 }
 
+publication:hover {
+    background-color: black;
+}
+
+publication:hover > img {
+    opacity: 0.5;
+}
+
+publication:hover > publication-information {
+    display: flex;
+    opacity:1;
+}
+
 publication::after{
     content: '';
     position: absolute;
     left: 0; top: 0;
     border-radius: 5px;
     width: 100%; height: 100%;
-    background: linear-gradient(rgba(0,0,0,0.8), rgba(0, 0, 0, 0.7),rgba(0, 0, 0, 0.2));
 }
 
 publication-information {
-    display: flex;
+    display: none;
     flex-direction: column;
     justify-content: start;
 }


### PR DESCRIPTION
Hi Guys, 

I'm new to GitHub and sort of new to coding, but I really want to learn more and support this project. I made a small visual tweak (that took me much longer to figure out than it should have) so that by default the beautiful manga posters are displayed on the website (since most of the time we can identify the manga by poster alone) and then the publication-information is shown once you hover over it. 

![image](https://github.com/C9Glax/tranga-website/assets/125827669/29d8d2bb-a28e-4bda-bdcf-81080715a54b)

If I've messed up something in the process or code then please lemme know, like I said, super new to collaborating on GitHub and stuff so any guidance is appreciated. 

~Dity
