### PR TITLE
Latest Chapter Downloaded/Available Indicator

### DIFF
--- a/Website/interaction.js
+++ b/Website/interaction.js
@@ -148,7 +148,7 @@ function GetNewMangaItems(){
     if(json.length > 0)
       newMangaResult.style.display = "flex";
     json.forEach(result => {
-      var mangaElement = CreateManga(result, newMangaConnector.value)
+      var mangaElement = CreateManga(result, newMangaConnector.value);
       newMangaResult.appendChild(mangaElement);
       mangaElement.addEventListener("click", (event) => {
         ShowMangaWindow(null, result, event, true);
@@ -161,13 +161,20 @@ function GetNewMangaItems(){
   });
 }
 
-//Returns a new "Publication" Item to display in the jobs section
+//Returns a new "Publication" Item to display in the library section
 function CreateManga(manga, connector){
+    //Create a publication HTML element
     var mangaElement = document.createElement('publication');
+
+    //Assign the manga an internal ID
     mangaElement.id = GetValidSelector(manga.internalId);
+    
+    //Append the manga image to the publication element
     var mangaImage = document.createElement('img');
     mangaImage.src = GetCoverUrl(manga.internalId);
     mangaElement.appendChild(mangaImage);
+    
+    //Append the publication information to the publication element
     var info = document.createElement('publication-information');
     var connectorName = document.createElement('connector-name');
     connectorName.innerText = connector;
@@ -178,6 +185,20 @@ function CreateManga(manga, connector){
     mangaName.innerText = manga.sortName;
     info.appendChild(mangaName);
     mangaElement.appendChild(info);
+
+    //Append the latest chapter to the publication element
+    var chapterNo = document.createElement('chapter-number');
+    
+    //If the latestChapterAvailable parameter is not equal to zero, then set the chapter number to this value. This assumes that the only time
+    //the latestChapterAvailable parameter would be non-zero is when searching for a new manga. Otherwise, set it to the latest downloaded chapter.
+    if (manga.latestChapterAvailable != 0) {
+      chapterNo.innerText = manga.latestChapterAvailable;
+      chapterNo.style.backgroundColor = "DodgerBlue";
+    } else {
+      chapterNo.innerText = manga.latestChapterDownloaded;
+      chapterNo.style.backgroundColor = "MediumSeaGreen";
+    }
+    mangaElement.appendChild(chapterNo);
     return mangaElement;
 }
 

--- a/Website/styles/style_default.css
+++ b/Website/styles/style_default.css
@@ -218,7 +218,7 @@ publication::after{
 }
 
 chapter-number {
-    display: flex;
+    display: none;
     font-size: 12pt;
     font-weight: bold;
     color:white;

--- a/Website/styles/style_default.css
+++ b/Website/styles/style_default.css
@@ -217,6 +217,20 @@ publication::after{
     background: linear-gradient(rgba(0,0,0,0.8), rgba(0, 0, 0, 0.7),rgba(0, 0, 0, 0.2));
 }
 
+chapter-number {
+    display: flex;
+    font-size: 12pt;
+    font-weight: bold;
+    color:white;
+    position:absolute;
+    bottom:0;
+    right:0;
+    margin: 10px 10px 10px 10px;
+    padding: 5px 15px;
+    z-index: 2;
+    border-radius: 5px;
+}
+
 publication-information {
     display: flex;
     flex-direction: column;

--- a/Website/styles/style_mangahover.css
+++ b/Website/styles/style_mangahover.css
@@ -209,7 +209,7 @@ publication{
 }
 
 chapter-number {
-    display: flex;
+    display: none;
     font-size: 12pt;
     font-weight: bold;
     color:white;

--- a/Website/styles/style_mangahover.css
+++ b/Website/styles/style_mangahover.css
@@ -208,6 +208,20 @@ publication{
     flex-shrink: 0;
 }
 
+chapter-number {
+    display: flex;
+    font-size: 12pt;
+    font-weight: bold;
+    color:white;
+    position:absolute;
+    bottom:0;
+    right:0;
+    margin: 10px 10px 10px 10px;
+    padding: 5px 15px;
+    z-index: 2;
+    border-radius: 5px;
+}
+
 publication:hover {
     background-color: black;
 }


### PR DESCRIPTION
Adds a feature that shows the latest chapter downloaded, in the default library view, or the latest chapter available, from the search menu. The latest chapter downloaded shows up as white text on a green background and the latest available chapter from a connector shows up as white text on a blue background.

![image](https://github.com/C9Glax/tranga-website/assets/125827669/93dc520a-05c8-4c55-801b-f2d650db87a6)
![image](https://github.com/C9Glax/tranga-website/assets/125827669/4eb9a20e-d064-41bc-af46-78ceb5ab0afe)

Currently, the display style has been set to none so that the feature is hidden until the API is ready for it, but the JS script code makes an important assumption: 
![image](https://github.com/C9Glax/tranga-website/assets/125827669/ca940f5c-f901-4ffd-b02b-d20118d48b09)

This was the only way I could get the one common JS function to return the correct value/color combo without having to add an indication of where the function was called from. If there's a better way to implement the logic for this then I'm all ears.

