### PR TITLE
Added button to settings pop-up to refresh library metadata through POST request

### DIFF
--- a/Website/apiConnector.js
+++ b/Website/apiConnector.js
@@ -168,6 +168,11 @@ function ChangeStyleSheet(sheet){
     PostData(uri);
 }
 
+function RefreshLibraryMetadata() {
+    var uri = `${apiUri}/Jobs/UpdateMetadata`;
+    PostData(uri);
+}
+
 function UpdateKomga(komgaUrl, komgaAuth){
     var uri = `${apiUri}/LibraryConnectors/Update?libraryConnector=Komga&komgaUrl=${komgaUrl}&komgaAuth=${komgaAuth}`;
     PostData(uri);

--- a/Website/index.html
+++ b/Website/index.html
@@ -104,6 +104,9 @@
             <div>
               <input type="submit" value="Update" onclick="UpdateSettings()">
             </div>
+            <div>
+              <input type="submit" value="Refresh Library Metadata" style="width: fit-content;"onclick="RefreshLibraryMetadata()">
+            </div>
           </popup-content>
         </popup-window>
       </popup>


### PR DESCRIPTION
![image](https://github.com/C9Glax/tranga-website/assets/125827669/b6ea2208-b1b3-461e-bc94-0fd66365aa3e)

I was toying with the idea of a bigger visual refresh for the settings page, just so it's easy to navigate on both desktop and mobile. Is there a preference between leaving the settings page as a pop-up or making it a separate page the user can navigate to?