### PR TITLE
Ability to override defaultApiUrl

### DIFF
--- a/Website/apiConnector.js
+++ b/Website/apiConnector.js
@@ -1,6 +1,4 @@
-﻿let apiUri = `${window.location.protocol}//${window.location.host.split(':')[0]}:6531`
-
-if(getCookie("apiUri") != ""){
+﻿if(getCookie("apiUri") != ""){
     apiUri = getCookie("apiUri");
 }
 setCookie("apiUri", apiUri);

--- a/Website/defaultApiUri.js
+++ b/Website/defaultApiUri.js
@@ -1,0 +1,1 @@
+let apiUri = `${window.location.protocol}//${window.location.host.split(':')[0]}:6531`

--- a/Website/index.html
+++ b/Website/index.html
@@ -294,7 +294,8 @@
       <p id="madeWith">Made with Blåhaj 🦈</p>
     </footer> 
   </wrapper>
-  
+
+  <script src="defaultApiUri.js"></script>
   <script src="apiConnector.js"></script>
   <script src="interaction.js"></script>
 </body>


### PR DESCRIPTION
When deploying in Kubernetes, you can override `defaultApiUri.js` with the following code:
```javascript
let apiUri = `https://tranga.lan/api/`;
```
This way, when you first access the site, there's no need to manually update the API endpoint in the settings.